### PR TITLE
ShowBackgroundOnTimer Setting

### DIFF
--- a/OnlyT/Properties/Resources.Designer.cs
+++ b/OnlyT/Properties/Resources.Designer.cs
@@ -1155,6 +1155,15 @@ namespace OnlyT.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show background on timer.
+        /// </summary>
+        public static string SHOW_BACKGROUND_TIMER {
+            get {
+                return ResourceManager.GetString("SHOW_BACKGROUND_TIMER", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show frame.
         /// </summary>
         public static string SHOW_CLOCK_FRAME {

--- a/OnlyT/Properties/Resources.resx
+++ b/OnlyT/Properties/Resources.resx
@@ -657,4 +657,7 @@
     <value>Note that the monitor is controlled by a command-line setting</value>
     <comment>In Settings page. Displayed above the monitor name when it has been specified via the command-line)</comment>
   </data>
+  <data name="SHOW_BACKGROUND_TIMER" xml:space="preserve">
+    <value>Show background on timer</value>
+  </data>
 </root>

--- a/OnlyT/Services/Options/Options.cs
+++ b/OnlyT/Services/Options/Options.cs
@@ -45,7 +45,7 @@
             CountdownFrame = true;
             TimerFrame = true;
             LogEventLevel = LogEventLevel.Information;
-            
+            ShowBackgroundOnTimer = true;
             AdjustClockFormat();
         }
 
@@ -56,6 +56,8 @@
         public bool CountdownFrame { get; set; }
 
         public ElementsToShow CountdownElementsToShow { get; set; }
+
+        public bool ShowBackgroundOnTimer { get; set; }
 
         public bool TimerFrame { get; set; }
 

--- a/OnlyT/ViewModel/SettingsPageViewModel.cs
+++ b/OnlyT/ViewModel/SettingsPageViewModel.cs
@@ -501,6 +501,20 @@
             }
         }
 
+        public bool ShowBackgroundOnTimer
+        {
+            get => _optionsService.Options.ShowBackgroundOnTimer;
+            set
+            {
+                if (_optionsService.Options.ShowBackgroundOnTimer != value)
+                {
+                    _optionsService.Options.ShowBackgroundOnTimer = value;
+                    RaisePropertyChanged();
+                    Messenger.Default.Send(new TimerFrameChangedMessage());
+                }
+            }
+        }
+
         public bool ShowTimeOfDayUnderTimer
         {
             get => _optionsService.Options.ShowTimeOfDayUnderTimer;

--- a/OnlyT/ViewModel/TimerOutputWindowViewModel.cs
+++ b/OnlyT/ViewModel/TimerOutputWindowViewModel.cs
@@ -1,4 +1,6 @@
-﻿namespace OnlyT.ViewModel
+﻿using System.Windows;
+
+namespace OnlyT.ViewModel
 {
     // ReSharper disable UnusedMember.Global
     using System;
@@ -153,6 +155,8 @@
 
         public bool DigitalTimeShowSeconds => _optionsService.Options.ShowDigitalSeconds;
 
+        public int ShowBackgroundOnTimer => _optionsService.Options.ShowBackgroundOnTimer ? 1 : 0;
+
         public bool SplitAndFullScreenModeIdentical()
         {
             return _optionsService.Options.AnalogueClockWidthPercent == 100;
@@ -266,6 +270,7 @@
         {
             RaisePropertyChanged(nameof(BorderThickness));
             RaisePropertyChanged(nameof(BackgroundOpacity));
+            RaisePropertyChanged(nameof(ShowBackgroundOnTimer));
         }
     }
 }

--- a/OnlyT/Windows/SettingsPage.xaml
+++ b/OnlyT/Windows/SettingsPage.xaml
@@ -235,6 +235,10 @@
                                   Style="{StaticResource SettingsCheckBox}"
                                   Content="{x:Static resx:Resources.SHOW_CLOCK_FRAME}" />
 
+                        <CheckBox IsChecked="{Binding ShowBackgroundOnTimer, Mode=TwoWay}" 
+                                  Style="{StaticResource SettingsCheckBox}"
+                                  Content="{x:Static resx:Resources.SHOW_BACKGROUND_TIMER}" />
+
                         <CheckBox IsChecked="{Binding ShowTimeOfDayUnderTimer, Mode=TwoWay}" 
                                   Style="{StaticResource SettingsCheckBox}"
                                   Content="{x:Static resx:Resources.TIME_UNDER_TIMER}" />

--- a/OnlyT/Windows/TimerOutputWindow.xaml
+++ b/OnlyT/Windows/TimerOutputWindow.xaml
@@ -24,7 +24,12 @@
             <ColumnDefinition Width="{Binding AnalogueClockColumnWidthPercentage, Converter={StaticResource ColWidthConverter}, Mode=OneWay}" />
             <ColumnDefinition Width="{Binding TimerColumnWidthPercentage, Converter={StaticResource ColWidthConverter}, Mode=OneWay}" />
         </Grid.ColumnDefinitions>
-
+        <Grid.Background >
+            <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0" Opacity="{Binding ShowBackgroundOnTimer}" >
+                <GradientStop Color="Black" Offset="1"/>
+                <GradientStop Color="#FF5D4343"/>
+            </LinearGradientBrush>
+        </Grid.Background>
         <Border Name="ClockPanel" 
                 CornerRadius="20" Grid.Column="0" Grid.ColumnSpan="2" 
                 BorderBrush="Beige" BorderThickness="{Binding BorderThickness}" Padding="10">
@@ -68,7 +73,7 @@
                     <RowDefinition Height="3*" />
                     <RowDefinition Height="2*" />
                 </Grid.RowDefinitions>
-
+                
                 <TextBlock Name="TimerTextBlock" Grid.Row="0"
                            Opacity="0.0"
                            HorizontalAlignment="Center"


### PR DESCRIPTION
…o timer

Thanks for sending a pull request! Please review the [guidelines for contributing](CONTRIBUTING.md), then fill out the blanks below.

What does this implement/fix? Explain your changes
--------------------------------------------------
Adds an option to the settings page for showing a background on the digital countdown (and required code to display the background on the timer window)

Does this close any currently open issues?
-----------------------------------------
No

Any other comments?
-------------------
A rather weird bug with our halls screen means the display turns off the input if a black background is displayed for a long time. The current 'fix' is to display the analogue timer at a really low percentage. This change resolved the error for us.
Thanks,
David
