### PR TITLE
feat: Add command line argument for enabling circuit visit

### DIFF
--- a/OnlyT/Services/CommandLine/CommandLineService.cs
+++ b/OnlyT/Services/CommandLine/CommandLineService.cs
@@ -46,6 +46,9 @@
                     }
                 });
 
+            p.Setup<bool>("covisit")
+                .Callback(s => { IsCircuitVisit = s; }).SetDefault(false);
+
             p.Parse(Environment.GetCommandLineArgs());
         }
 
@@ -64,6 +67,8 @@
         public bool Automate { get; set; }
 
         public DateTime? DateTimeOnLaunch { get; set; }
+
+        public bool IsCircuitVisit { get; set; }
 
         public bool IsTimerMonitorSpecified => TimerMonitorIndex > 0;
 

--- a/OnlyT/Services/CommandLine/ICommandLineService.cs
+++ b/OnlyT/Services/CommandLine/ICommandLineService.cs
@@ -15,6 +15,8 @@
         int TimerMonitorIndex { get; set; }
 
         int CountdownMonitorIndex { get; set; }
+        
+        bool IsCircuitVisit { get; set; }
 
         bool IsTimerMonitorSpecified { get; }
 

--- a/OnlyT/Services/Options/OptionsService.cs
+++ b/OnlyT/Services/Options/OptionsService.cs
@@ -272,8 +272,8 @@ namespace OnlyT.Services.Options
         private void ResetCircuitVisit()
         {
             // when the settings are read we ignore this saved setting 
-            // and reset to false...
-            _options!.IsCircuitVisit = false;
+            // and reset to command line value, if any (defaults to false)...
+            _options!.IsCircuitVisit = _commandLineService.IsCircuitVisit;
         }
 
         private void SetMidWeekOrWeekend()


### PR DESCRIPTION
What does this implement/fix? Explain your changes
--------------------------------------------------
Gives the ability to start OnlyT from the command line with the CO visit switch enabled. One could use this to devise several different ways of starting up OnlyT automatically with the Circuit Visit mode enabled.

Does this close any currently open issues?
------------------------------------------
No

Any other comments?
-------------------
Works with: `OnlyT.exe --covisit`