### PR TITLE
Upgrade all projects to dotnet 6 and update all dependencies

### DIFF
--- a/CreateDeliverables.cmd
+++ b/CreateDeliverables.cmd
@@ -23,17 +23,17 @@ IF %ERRORLEVEL% NEQ 0 goto ERROR
 
 ECHO.
 ECHO Copying items into delivery
-xcopy OnlyTFirewallPorts\bin\Release\net5.0\publish\*.* OnlyT\bin\Release\net5.0-windows\publish /q /s /y /d
+xcopy OnlyTFirewallPorts\bin\Release\net6.0\publish\*.* OnlyT\bin\Release\net6.0-windows\publish /q /s /y /d
 IF %ERRORLEVEL% NEQ 0 goto ERROR
 
 ECHO.
 ECHO Removing unwanted x64 DLLs
-del OnlyT\bin\Release\net5.0-windows\publish\libmp3lame.64.dll
+del OnlyT\bin\Release\net6.0-windows\publish\libmp3lame.64.dll
 IF %ERRORLEVEL% NEQ 0 goto ERROR
 
 ECHO.
 ECHO Removing unwanted translations
-rd OnlyT\bin\Release\net5.0-windows\publish\id-ID /q /s
+rd OnlyT\bin\Release\net6.0-windows\publish\id-ID /q /s
 IF %ERRORLEVEL% NEQ 0 goto ERROR
 
 ECHO.
@@ -43,7 +43,7 @@ IF %ERRORLEVEL% NEQ 0 goto ERROR
 
 ECHO.
 ECHO Create portable zip
-powershell Compress-Archive -Path OnlyT\bin\Release\net5.0-windows\publish\* -DestinationPath Installer\Output\OnlyTPortable.zip 
+powershell Compress-Archive -Path OnlyT\bin\Release\net6.0-windows\publish\* -DestinationPath Installer\Output\OnlyTPortable.zip 
 IF %ERRORLEVEL% NEQ 0 goto ERROR
 
 goto SUCCESS

--- a/OnlyT.AnalogueClock/OnlyT.AnalogueClock.csproj
+++ b/OnlyT.AnalogueClock/OnlyT.AnalogueClock.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Nullable>Enable</Nullable>
     <UseWPF>true</UseWPF>

--- a/OnlyT.AnalogueClock/OnlyT.AnalogueClock.csproj
+++ b/OnlyT.AnalogueClock/OnlyT.AnalogueClock.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.37.0.45539">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/OnlyT.Common/OnlyT.Common.csproj
+++ b/OnlyT.Common/OnlyT.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Nullable>Enable</Nullable>
   </PropertyGroup>

--- a/OnlyT.Common/OnlyT.Common.csproj
+++ b/OnlyT.Common/OnlyT.Common.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.37.0.45539">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/OnlyT.CountdownTimer/OnlyT.CountdownTimer.csproj
+++ b/OnlyT.CountdownTimer/OnlyT.CountdownTimer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Nullable>Enable</Nullable>
     <UseWPF>true</UseWPF>

--- a/OnlyT.CountdownTimer/OnlyT.CountdownTimer.csproj
+++ b/OnlyT.CountdownTimer/OnlyT.CountdownTimer.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.37.0.45539">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/OnlyT.Report/OnlyT.Report.csproj
+++ b/OnlyT.Report/OnlyT.Report.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Nullable>Enable</Nullable>
   </PropertyGroup>

--- a/OnlyT.Report/OnlyT.Report.csproj
+++ b/OnlyT.Report/OnlyT.Report.csproj
@@ -12,10 +12,10 @@
 
   <ItemGroup>
     <PackageReference Include="LiteDB" Version="5.0.11" />
-    <PackageReference Include="PdfSharpCore" Version="1.2.17" />
-    <PackageReference Include="PdfSharpCore.Charting" Version="0.1.1" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.37.0.45539">
+    <PackageReference Include="PdfSharpCore" Version="1.3.24" />
+    <PackageReference Include="PdfSharpCore.Charting" Version="1.3.24" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/OnlyT.Tests/OnlyT.Tests.csproj
+++ b/OnlyT.Tests/OnlyT.Tests.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.9" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/OnlyT.Tests/OnlyT.Tests.csproj
+++ b/OnlyT.Tests/OnlyT.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>Enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/OnlyT/OnlyT.csproj
+++ b/OnlyT/OnlyT.csproj
@@ -20,17 +20,17 @@
 
   <ItemGroup>
     <PackageReference Include="FluentCommandLineParser-netstandard" Version="1.4.3.13" />
-    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Toolkit.Mvvm" Version="7.1.2" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
-    <PackageReference Include="NAudio" Version="2.0.1" />
-    <PackageReference Include="NAudio.Lame" Version="2.0.0" />
+    <PackageReference Include="NAudio" Version="2.1.0" />
+    <PackageReference Include="NAudio.Lame" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUglify" Version="1.20.0" />
     <PackageReference Include="QRCoder" Version="1.4.3" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.37.0.45539">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/OnlyT/OnlyT.csproj
+++ b/OnlyT/OnlyT.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Nullable>Enable</Nullable>
     <UseWPF>true</UseWPF>

--- a/OnlyT/Resources/TimersHtmlTemplate.html
+++ b/OnlyT/Resources/TimersHtmlTemplate.html
@@ -314,7 +314,6 @@
                     return "";
 
                 case "Timer":
-                {
                     onlineToOfflineCount = 0;
                     offlineTextElem.style.display = "none";
                     document.getElementById("timers").style.display = "";
@@ -331,10 +330,8 @@
                     return currentlyCountingUp
                         ? getTimeDisplayStringCountingUp(clientTimerTotalElapsedSecs)
                         : getTimeDisplayStringCountingDown(clientTimerTotalElapsedSecs, currentTargetSecs);
-                }
 
                 default:
-                    //
                     if (!timersLoaded || (timersLoaded && onlineToOfflineCount >= MAX_OFFLINE_TO_OFFLINE_COUNT)) {
                         onlineToOfflineCount++;
                         offlineTextElem.style.display = "";
@@ -389,7 +386,7 @@
                 }
             }
 
-            setTimeout(updateTimer, 100);	// every 1/100 sec
+            setTimeout(updateTimer, 100); // every 1/100 sec
         }
 
         getOnlyTJson();

--- a/OnlyT/Services/Bell/TimerBell.cs
+++ b/OnlyT/Services/Bell/TimerBell.cs
@@ -43,6 +43,7 @@ namespace OnlyT.Services.Bell
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "<Pending>")]
         public void Play(int volumePercent)
         {
             if (!IsPlaying)

--- a/OnlyT/Utils/BitmapConverter.cs
+++ b/OnlyT/Utils/BitmapConverter.cs
@@ -6,6 +6,7 @@
 
     internal static class BitmapConverter
     {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "<Pending>")]
         public static BitmapImage Convert(Bitmap src)
         {
             var ms = new MemoryStream();

--- a/OnlyT/Utils/QRCodeGeneration.cs
+++ b/OnlyT/Utils/QRCodeGeneration.cs
@@ -7,7 +7,8 @@
     internal static class QRCodeGeneration
     {
         private static readonly ConcurrentDictionary<string, BitmapImage> Cache = new();
-        
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "<Pending>")]
         public static BitmapImage CreateQRCode(string url)
         {
             if (!Cache.TryGetValue(url, out var result))

--- a/OnlyT/Utils/WebUtils.cs
+++ b/OnlyT/Utils/WebUtils.cs
@@ -1,7 +1,7 @@
 ﻿namespace OnlyT.Utils
 {
     using System.Net;
-    using System.Text;
+    using System.Net.Http;
     using System.Threading;
 
     internal static class WebUtils
@@ -38,9 +38,14 @@
 
         private static string InternalLoadWithUserAgent(string url)
         {
-            using var wc = new WebClient { Encoding = Encoding.UTF8 };
-            wc.Headers.Add("user-agent", UserAgentString);
-            return wc.DownloadString(url);
+            using var handler = new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate };
+            using var request = new HttpRequestMessage { RequestUri = new(url), Method = HttpMethod.Get };
+            using var client = new HttpClient(handler);
+            client.DefaultRequestHeaders.Add("user-agent", UserAgentString);
+
+            var response = client.Send(request);
+            response.EnsureSuccessStatusCode();
+            return response.Content.ReadAsStringAsync().Result;
         }
     }
 }

--- a/OnlyTFirewallPorts/OnlyTFirewallPorts.csproj
+++ b/OnlyTFirewallPorts/OnlyTFirewallPorts.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.37.0.45539">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/OnlyTFirewallPorts/OnlyTFirewallPorts.csproj
+++ b/OnlyTFirewallPorts/OnlyTFirewallPorts.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Nullable>Enable</Nullable>


### PR DESCRIPTION
What does this implement/fix? Explain your changes
--------------------------------------------------
Puts the projects at the latest .net version (6.0) as well as the latest dependency versions. .net 5 reached end of life on May 10th 2022 so probably a good idea to move over although this was done mostly as a way to see if the application responds better on my remote server.

Does this close any currently open issues?
------------------------------------------
No.

Any other comments?
-------------------
This probably requires VS 2022 going forward and will require a change in the build settings in AppVeyor to use Visual Studio 2022 as the build worker image.