### PR TITLE
feat(file-based): add adaptive attribute to file-based mode

### DIFF
--- a/OnlyT/Services/TalkSchedule/TalkScheduleFileBased.cs
+++ b/OnlyT/Services/TalkSchedule/TalkScheduleFileBased.cs
@@ -33,9 +33,9 @@
 
                         foreach (XElement elem in items.Elements("item"))
                         {
-                            var name = (string?) elem.Attribute("name") ?? $"Unknown name {talkId}";
-                            var sectionNameInternal = (string?) elem.Attribute("section") ?? $"Unknown section {talkId}";
-                            var sectionNameLocalised = (string?) elem.Attribute("section") ?? $"Unknown section {talkId}";
+                            var name = (string?)elem.Attribute("name") ?? $"Unknown name {talkId}";
+                            var sectionNameInternal = (string?)elem.Attribute("section") ?? $"Unknown section {talkId}";
+                            var sectionNameLocalised = (string?)elem.Attribute("section") ?? $"Unknown section {talkId}";
 
                             result.Add(new TalkScheduleItem(talkId, name, sectionNameInternal, sectionNameLocalised)
                             {
@@ -44,7 +44,8 @@
                                 Editable = AttributeToBool(elem.Attribute("editable"), false),
                                 BellApplicable = AttributeToBool(elem.Attribute("bell"), false),
                                 AutoBell = autoBell,
-                                PersistFinalTimerValue = AttributeToBool(elem.Attribute("persist"), false)
+                                PersistFinalTimerValue = AttributeToBool(elem.Attribute("persist"), false),
+                                AllowAdaptive = AttributeToBool(elem.Attribute("adaptive"), false)
                             });
 
                             ++talkId;
@@ -96,8 +97,8 @@
 
         private static TimeSpan StringToTimeSpan(string s)
         {
-            return TimeSpan.TryParse(s, out var result) 
-                ? result 
+            return TimeSpan.TryParse(s, out var result)
+                ? result
                 : default;
         }
     }

--- a/talk_schedule.xml
+++ b/talk_schedule.xml
@@ -21,9 +21,12 @@
   <!--Use the optional "persist" attribute to specify that a timer value should remain on-screen after 
   the timer has stopped (useful for a chairman to note the speaker's time)-->
 
+  <!--Use the optional "adaptive" attribute to specify whether the talk duration can adapt based on the 
+  meeting's progress (false by default)-->
+
   <items>
     <item name="Welcome" duration="00:03:00" editable="true" countup="true" />
-    <item name="Keynote" duration="01:00:00" editable="true" bell="true" countup="false" persist="true" />    
+    <item name="Keynote" duration="01:00:00" editable="true" bell="true" countup="false" persist="true" adaptive="false" />
     <item name="Concluding Comments" duration="00:03:00" editable="true" />
   </items>  
   


### PR DESCRIPTION
What does this implement/fix? Explain your changes
--------------------------------------------------
This pull request implements a new feature that allows users to add adaptive talks in **file-based mode** through `adaptive` attribute.

The changes include:
- reads `adaptive` attribute from file
- adds its usage in sample file

Does this close any currently open issues?
------------------------------------------
No.

Any other comments?
-------------------
No.

Thanks!