### PR TITLE
fix: If there is no second part in CL section don't return it

### DIFF
--- a/OnlyT/Services/TalkSchedule/TalkScheduleAuto.cs
+++ b/OnlyT/Services/TalkSchedule/TalkScheduleAuto.cs
@@ -355,11 +355,14 @@
                 new TimeSpan(0, 51, 40),
                 TimeSpan.FromMinutes(timerPart1.Minutes)));
 
-            result.Add(CreateLivingItem(
-                TalkTypesAutoMode.LivingPart2,
-                Properties.Resources.TALK_LIVING2,
-                new TimeSpan(0, 51, 40).Add(TimeSpan.FromMinutes(timerPart1.Minutes)),
-                TimeSpan.FromMinutes(timerPart2?.Minutes ?? 0)));
+            if (timerPart2?.Minutes > 0)
+            {
+                result.Add(CreateLivingItem(
+                    TalkTypesAutoMode.LivingPart2,
+                    Properties.Resources.TALK_LIVING2,
+                    new TimeSpan(0, 51, 40).Add(TimeSpan.FromMinutes(timerPart1.Minutes)),
+                    TimeSpan.FromMinutes(timerPart2.Minutes)));
+            }
 
             if (isCircuitVisit)
             {


### PR DESCRIPTION
What does this implement/fix? Explain your changes
--------------------------------------------------
Appears to have been on purpose but I am not finding any usefulness to having an empty second part in the Christian Life and Ministry section when one is not scheduled.

Does this close any currently open issues?
------------------------------------------
No

Any other comments?
-------------------
If this is on purpose for some reason feel free to close.